### PR TITLE
Bump actions/checkout from v4 to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
         model: [yolo11n, yolov8s-worldv2, yoloe11s]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/yolo11n/predict.py
+++ b/yolo11n/predict.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from typing import Optional
+from __future__ import annotations
 
 from cog import BaseModel, BasePredictor, Input, Path
 from ultralytics import YOLO
@@ -9,8 +9,8 @@ from ultralytics import YOLO
 class Output(BaseModel):
     """Output model for predictions."""
 
-    image: Optional[Path] = None
-    json_str: Optional[str] = None
+    image: Path | None = None
+    json_str: str | None = None
 
 
 class Predictor(BasePredictor):

--- a/yoloe11s/predict.py
+++ b/yoloe11s/predict.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from typing import Optional
+from __future__ import annotations
 
 from cog import BaseModel, BasePredictor, Input, Path
 from ultralytics import YOLOE
@@ -9,8 +9,8 @@ from ultralytics import YOLOE
 class Output(BaseModel):
     """Output model for predictions."""
 
-    image: Optional[Path] = None
-    json_str: Optional[str] = None
+    image: Path | None = None
+    json_str: str | None = None
 
 
 class Predictor(BasePredictor):

--- a/yolov8s-worldv2/predict.py
+++ b/yolov8s-worldv2/predict.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from typing import Optional
+from __future__ import annotations
 
 from cog import BaseModel, BasePredictor, Input, Path
 from ultralytics import YOLOWorld
@@ -9,8 +9,8 @@ from ultralytics import YOLOWorld
 class Output(BaseModel):
     """Output model for predictions."""
 
-    image: Optional[Path] = None
-    json_str: Optional[str] = None
+    image: Path | None = None
+    json_str: str | None = None
 
 
 class Predictor(BasePredictor):


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR modernizes the repo’s GitHub Actions and Python type hints, improving maintainability and keeping the Replicate predictors up to date 🚀

### 📊 Key Changes
- Updated GitHub Actions checkout steps from `actions/checkout@v4` to `actions/checkout@v6` in both CI and push workflows ⚙️
- Replaced `typing.Optional` imports with `from __future__ import annotations` in predictor files for:
  - `yolo11n`
  - `yoloe11s`
  - `yolov8s-worldv2`
- Simplified output type annotations from `Optional[Path]` and `Optional[str]` to modern `Path | None` and `str | None` ✨
- No model logic or prediction behavior was changed; updates are focused on code style and workflow maintenance ✅

### 🎯 Purpose & Impact
- Keeps automation workflows aligned with newer GitHub Actions versions, which can help with long-term CI reliability and compatibility 🔄
- Modernizes Python code to use cleaner, more readable type hints, making the predictor files easier to maintain 🧹
- Reduces technical debt without affecting how users run or consume these Replicate models 🤝
- Low-risk update overall: developers benefit from cleaner infrastructure and code, while end users should see no functional changes 📦