### PR TITLE
Bump actions/setup-python from v5 to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: Setup uv

--- a/yolo11n/predict.py
+++ b/yolo11n/predict.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from typing import Optional
+from __future__ import annotations
 
 from cog import BaseModel, BasePredictor, Input, Path
 from ultralytics import YOLO
@@ -9,8 +9,8 @@ from ultralytics import YOLO
 class Output(BaseModel):
     """Output model for predictions."""
 
-    image: Optional[Path] = None
-    json_str: Optional[str] = None
+    image: Path | None = None
+    json_str: str | None = None
 
 
 class Predictor(BasePredictor):

--- a/yoloe11s/predict.py
+++ b/yoloe11s/predict.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from typing import Optional
+from __future__ import annotations
 
 from cog import BaseModel, BasePredictor, Input, Path
 from ultralytics import YOLOE
@@ -9,8 +9,8 @@ from ultralytics import YOLOE
 class Output(BaseModel):
     """Output model for predictions."""
 
-    image: Optional[Path] = None
-    json_str: Optional[str] = None
+    image: Path | None = None
+    json_str: str | None = None
 
 
 class Predictor(BasePredictor):

--- a/yolov8s-worldv2/predict.py
+++ b/yolov8s-worldv2/predict.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-from typing import Optional
+from __future__ import annotations
 
 from cog import BaseModel, BasePredictor, Input, Path
 from ultralytics import YOLOWorld
@@ -9,8 +9,8 @@ from ultralytics import YOLOWorld
 class Output(BaseModel):
     """Output model for predictions."""
 
-    image: Optional[Path] = None
-    json_str: Optional[str] = None
+    image: Path | None = None
+    json_str: str | None = None
 
 
 class Predictor(BasePredictor):


### PR DESCRIPTION
Bump actions/setup-python from v5 to v6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR modernizes the repo by upgrading GitHub Actions to `setup-python@v6` and updating several predictor files to use newer Python type hint syntax.

### 📊 Key Changes
- ⬆️ Updated GitHub Actions workflows in `.github/workflows/ci.yml` and `.github/workflows/push.yml`:
  - `actions/setup-python@v5` → `actions/setup-python@v6`
- 🧹 Refactored type annotations in prediction scripts for:
  - `yolo11n/predict.py`
  - `yoloe11s/predict.py`
  - `yolov8s-worldv2/predict.py`
- 🐍 Replaced `from typing import Optional` with `from __future__ import annotations`
- ✨ Simplified optional field annotations:
  - `Optional[Path]` → `Path | None`
  - `Optional[str]` → `str | None`

### 🎯 Purpose & Impact
- ✅ Keeps CI and release workflows current with the latest GitHub Actions version, helping maintain compatibility and reliability
- 📘 Makes the Python code cleaner and more modern, aligning with newer Python standards
- 🛠️ Reduces dependency on older typing syntax, which can improve readability and long-term maintainability
- 👥 Minimal user-facing change: this is mainly an internal maintenance update, but it helps the repo stay healthy and easier to support over time