### PR TITLE
Set workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@
 
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,9 @@
 
 name: Push YOLO to Replicate
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- add explicit `contents: read` permissions to CI and Replicate push workflows

## CodeQL alerts
Addresses:
- https://github.com/ultralytics/replicate/security/code-scanning/1
- https://github.com/ultralytics/replicate/security/code-scanning/2

## Validation
- Parsed workflow YAML with `yaml.safe_load()`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR updates GitHub Actions workflows to use explicit read-only repository permissions, improving CI/CD security without changing functionality.

### 📊 Key Changes
- Added a top-level `permissions` block with `contents: read` to `.github/workflows/ci.yml`
- Added the same `permissions` setting to `.github/workflows/push.yml`
- Applies to both:
  - the main CI workflow
  - the workflow that pushes YOLO to Replicate

### 🎯 Purpose & Impact
- Improves security by limiting GitHub Actions workflows to the minimum access they need 🛡️
- Reduces risk from overly broad default token permissions in automated workflows
- Aligns the repository with GitHub Actions security best practices ✅
- Should have no impact on normal development or deployment behavior, since these workflows only need read access to repository contents 🚀