### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,17 @@ cd replicate
 
 # Deploy YOLO11n
 cd yolo11n
+python download.py
 cog login
 cog push r8.im/ultralytics/yolo11n
 
 # Or deploy another configured model
 cd ../yolov8s-worldv2
+python download.py
 cog push r8.im/ultralytics/yolov8s-worldv2
 
 cd ../yoloe11s
+python download.py
 cog push r8.im/ultralytics/yoloe-11s
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # 🚀 Ultralytics Replicate
 
-Deploy YOLO11n to Replicate at https://replicate.com/ultralytics/yolo11n with ready-to-use Cog configuration and automated CI/CD workflow.
+Deploy Ultralytics YOLO models to Replicate with ready-to-use Cog configurations and automated CI/CD workflows.
 
-[![Push YOLO11n to Replicate](https://github.com/ultralytics/replicate/actions/workflows/push.yml/badge.svg)](https://github.com/ultralytics/replicate/actions/workflows/push.yml)
+[![Push YOLO to Replicate](https://github.com/ultralytics/replicate/actions/workflows/push.yml/badge.svg)](https://github.com/ultralytics/replicate/actions/workflows/push.yml)
 [![Ultralytics Actions](https://github.com/ultralytics/replicate/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/replicate/actions/workflows/format.yml)
 [![Codecov](https://codecov.io/github/ultralytics/replicate/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/replicate)
 
@@ -16,7 +16,8 @@ Deploy YOLO11n to Replicate at https://replicate.com/ultralytics/yolo11n with re
 
 ## 🗂️ Repository Structure
 
-This repository provides optimized Replicate deployment for the YOLO11n model with automated CI/CD workflow.
+This repository provides optimized Replicate deployments for YOLO11n, YOLOv8s WorldV2, and YOLOE-11S models with an
+automated CI/CD workflow.
 
 ```plaintext
 ultralytics/replicate/
@@ -25,13 +26,22 @@ ultralytics/replicate/
 │   ├── cog.yaml              # Cog configuration
 │   ├── predict.py            # Prediction interface
 │   └── README.md             # Model documentation
+├── yolov8s-worldv2/          # YOLOv8s WorldV2 model deployment
+│   ├── cog.yaml              # Cog configuration
+│   ├── predict.py            # Prediction interface
+│   └── README.md             # Model documentation
+├── yoloe11s/                 # YOLOE-11S model deployment
+│   ├── cog.yaml              # Cog configuration
+│   ├── predict.py            # Prediction interface
+│   └── README.md             # Model documentation
+├── assets/                   # Sample images for workflow smoke tests
 │
 ├── .github/workflows/        # Automated deployment
 │   ├── push.yml              # Model deployment workflow
 │   ├── ci.yml                # Code quality checks
 │   └── format.yml            # Code formatting
 │
-├── test_prediction.py        # Local testing utility
+├── test_prediction.py        # Local YOLO11n testing utility
 ├── requirements.txt          # Dependencies
 ├── LICENSE                   # AGPL-3.0 license
 └── README.md                 # This file
@@ -39,19 +49,26 @@ ultralytics/replicate/
 
 ## ⚡ Quick Start
 
-### Deploy YOLO11n Model
+### Deploy a Model
 
-Model will deploy to https://replicate.com/ultralytics/yolo11n:
+Models deploy to the corresponding Replicate endpoints:
 
 ```bash
 # Clone repository
 git clone https://github.com/ultralytics/replicate.git
 cd replicate
 
-# Deploy to Replicate
+# Deploy YOLO11n
 cd yolo11n
 cog login
 cog push r8.im/ultralytics/yolo11n
+
+# Or deploy another configured model
+cd ../yolov8s-worldv2
+cog push r8.im/ultralytics/yolov8s-worldv2
+
+cd ../yoloe11s
+cog push r8.im/ultralytics/yoloe-11s
 ```
 
 ### Automated Deployment with GitHub Actions
@@ -61,8 +78,8 @@ cog push r8.im/ultralytics/yolo11n
    - Add `REPLICATE_API_TOKEN` with your [Replicate API token](https://replicate.com/auth/token)
 
 2. **Deploy:**
-   - **Manual**: Actions tab → "Push YOLO11n to Replicate" → Run workflow
-   - **Automatic**: Push changes to `main` branch auto-deploys
+   - **Manual**: Actions tab → "Push YOLO to Replicate" → Run workflow
+   - **Automatic**: Push changes to `main` builds, tests, and deploys each configured model
 
 ## 🛠️ Installation
 
@@ -79,22 +96,22 @@ For local development and testing:
 pip install -r requirements.txt
 ```
 
-## 🎯 YOLO11n Model
+## 🎯 Available Models
 
-- **Purpose**: Official YOLO11n object detection
-- **Parameters**: 2.6M parameters
-- **Classes**: 80 COCO classes
-- **Performance**: 39.5 mAP50-95 on COCO dataset
-- **Speed**: Optimized for real-time inference
+| Directory | Replicate model | Predictor | Notes |
+| --- | --- | --- | --- |
+| `yolo11n/` | `r8.im/ultralytics/yolo11n` | `YOLO` | Official YOLO11n object detection model |
+| `yolov8s-worldv2/` | `r8.im/ultralytics/yolov8s-worldv2` | `YOLOWorld` | Open-vocabulary YOLOv8s WorldV2 model |
+| `yoloe11s/` | `r8.im/ultralytics/yoloe-11s` | `YOLOE` | YOLOE-11S segmentation model with class prompt support |
 
 ## 🔧 Model Setup
 
-The model will be automatically downloaded by ultralytics when needed:
+Each model directory includes a `download.py` script used by the deployment workflow before `cog build`:
 
-```python
-from ultralytics import YOLO
-
-model = YOLO("yolo11n.pt")  # Downloads automatically if not present
+```bash
+python yolo11n/download.py
+python yolov8s-worldv2/download.py
+python yoloe11s/download.py
 ```
 
 ## 🧪 Local Testing
@@ -103,16 +120,17 @@ Test the model locally before deploying:
 
 ```bash
 # Test YOLO11n
-python test_prediction.py --model yolo11n --image test.jpg
+python yolo11n/download.py
+python test_prediction.py --model yolo11n --image assets/bus.jpg
 ```
 
 ## 🚀 Features
 
 - **🏎️ Optimized**: PyTorch model for fast inference
 - **🤖 Automated**: GitHub Actions for CI/CD
-- **📦 Ready-to-use**: Pre-configured YOLO11n deployment
+- **📦 Ready-to-use**: Pre-configured deployments for multiple YOLO models
 - **📊 Scalable**: Auto-scaling Replicate infrastructure
-- **🎯 Simple**: Single model focus
+- **🎯 Focused**: One Cog configuration per model
 
 ## 💡 Contribute
 

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ pip install -r requirements.txt
 
 ## 🎯 Available Models
 
-| Directory | Replicate model | Predictor | Notes |
-| --- | --- | --- | --- |
-| `yolo11n/` | `r8.im/ultralytics/yolo11n` | `YOLO` | Official YOLO11n object detection model |
-| `yolov8s-worldv2/` | `r8.im/ultralytics/yolov8s-worldv2` | `YOLOWorld` | Open-vocabulary YOLOv8s WorldV2 model |
-| `yoloe11s/` | `r8.im/ultralytics/yoloe-11s` | `YOLOE` | YOLOE-11S segmentation model with class prompt support |
+| Directory          | Replicate model                     | Predictor   | Notes                                                  |
+| ------------------ | ----------------------------------- | ----------- | ------------------------------------------------------ |
+| `yolo11n/`         | `r8.im/ultralytics/yolo11n`         | `YOLO`      | Official YOLO11n object detection model                |
+| `yolov8s-worldv2/` | `r8.im/ultralytics/yolov8s-worldv2` | `YOLOWorld` | Open-vocabulary YOLOv8s WorldV2 model                  |
+| `yoloe11s/`        | `r8.im/ultralytics/yoloe-11s`       | `YOLOE`     | YOLOE-11S segmentation model with class prompt support |
 
 ## 🔧 Model Setup
 

--- a/yolo11n/README.md
+++ b/yolo11n/README.md
@@ -23,7 +23,7 @@ Deploy the official YOLO11n model to Replicate with PyTorch inference at https:/
 ## Configuration
 
 - **GPU**: Disabled by default (CPU inference)
-- **Python**: 3.11 with PyTorch 2.0+
+- **Python**: 3.12 with PyTorch 2.0+
 - **Framework**: Ultralytics 8.3+
 - **Input**: Single image with configurable confidence/IoU thresholds
 - **Output**: Annotated image with detected objects

--- a/yoloe11s/README.md
+++ b/yoloe11s/README.md
@@ -19,7 +19,8 @@ Deploy the official YOLOE-11S model to Replicate with PyTorch inference at <http
 
 ## Model Files
 
-**Note:** The model weights (`yoloe-11s-seg.pt` and `yoloe-11s-seg-pf.pt`) will be downloaded before the container builds.
+**Note:** `download.py` stages the YOLOE weights (`yoloe-11s-seg.pt` and `yoloe-11s-seg-pf.pt`) before the container builds.
+The Cog environment installs the CLIP dependency configured in `cog.yaml` for prompt-based inference.
 
 ## Configuration
 

--- a/yoloe11s/README.md
+++ b/yoloe11s/README.md
@@ -19,7 +19,7 @@ Deploy the official YOLOE-11S model to Replicate with PyTorch inference at <http
 
 ## Model Files
 
-**Note:** The model weights (`yoloe-11s-seg.pt`) and (`mobileclip_blt.ts`) will be automatically downloaded by ultralytics when the container starts.
+**Note:** The model weights (`yoloe-11s-seg.pt` and `yoloe-11s-seg-pf.pt`) will be downloaded before the container builds.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- updates the root README for the current three-model Replicate workflow
- corrects nested model README details for Python version and YOLOE weights
- preserves existing badges, backlinks, and social links

## Validation
- git diff --check
- lychee --no-progress --accept 200,429 README.md yolo11n/README.md yoloe11s/README.md yolov8s-worldv2/README.md
- python -m py_compile test_prediction.py yolo11n/predict.py yoloe11s/predict.py yolov8s-worldv2/predict.py yolo11n/download.py yoloe11s/download.py yolov8s-worldv2/download.py
- python test_prediction.py --help
- parsed all three cog.yaml files with PyYAML

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR expands the `ultralytics/replicate` repo from a single YOLO11n deployment into a multi-model Replicate deployment setup, with clearer docs, model-specific download steps, and updated workflow guidance.

### 📊 Key Changes
- 📦 **Broadened repository scope** from only YOLO11n to support multiple Ultralytics models:
  - `yolo11n`
  - `yolov8s-worldv2`
  - `yoloe11s`
- 📝 **Reworked the main `README.md`** to describe the repo as a general Ultralytics-to-Replicate deployment template rather than a YOLO11n-only project.
- 🗂️ **Updated repository structure docs** to show new model directories and shared test assets.
- ⚙️ **Revised deployment instructions** so users can deploy any supported model, including running each model’s `download.py` before `cog push`.
- 🤖 **Clarified GitHub Actions behavior**:
  - Workflow naming changed from “Push YOLO11n to Replicate” to “Push YOLO to Replicate”
  - CI/CD now builds, tests, and deploys each configured model on `main`
- 📋 **Added an “Available Models” table** summarizing Replicate endpoints, predictor classes, and model purposes.
- 🔽 **Documented explicit model staging via `download.py`** instead of relying only on runtime auto-download behavior.
- 🧪 **Improved local testing instructions** by using a sample asset (`assets/bus.jpg`) and making YOLO11n testing steps more explicit.
- 🐍 **Updated `yolo11n` documentation** to note Python 3.12 instead of 3.11.
- 🧠 **Improved `yoloe11s` docs** to clarify pre-build weight staging and CLIP dependency setup for prompt-based inference.

### 🎯 Purpose & Impact
- 🌍 **Makes the repo more useful to a wider audience** by supporting multiple model types, not just one detection model.
- 🚀 **Simplifies deployment to Replicate** with clearer, repeatable per-model setup steps.
- 🧩 **Improves maintainability** by organizing one Cog configuration per model, making future additions easier.
- ✅ **Reduces deployment surprises** by explicitly downloading required weights before build time.
- 📚 **Improves onboarding** for both developers and non-experts through clearer documentation and examples.
- 🔄 **Strengthens automation** so changes pushed to `main` can validate and deploy all configured models consistently.