### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
         model: [yolo11n, yolov8s-worldv2, yoloe11s]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions `checkout` step from `actions/checkout@v6` to `actions/checkout@v7` in the repository’s CI and push workflows.

### 📊 Key Changes
- Updated `.github/workflows/ci.yml` to use `actions/checkout@v7` instead of `@v6`.
- Updated `.github/workflows/push.yml` to use `actions/checkout@v7` instead of `@v6`.
- No model logic, training code, or inference behavior was changed—this is a workflow maintenance update only. 🛠️

### 🎯 Purpose & Impact
- Keeps the repository’s GitHub Actions workflows up to date with the latest supported checkout action. ✅
- Helps improve long-term reliability, compatibility, and maintainability of automated CI and push processes. 🔄
- Reduces the risk of using outdated workflow dependencies, with little to no impact on end users or model behavior. 📦