### PR TITLE
Add YOLO26 Replicate deployment with runtime size selection

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,10 +42,6 @@ jobs:
       - name: Test model
         working-directory: ${{ matrix.model }}
         run: cog predict -i image=@../assets/bus.jpg -i conf=0.25 -i iou=0.45
-      - name: Test model size selection (temporary, yolo26 only)
-        if: matrix.model == 'yolo26'
-        working-directory: ${{ matrix.model }}
-        run: cog predict -i image=@../assets/bus.jpg -i model_size=x
       - name: Push to Replicate
         if: github.ref == 'refs/heads/main'
         working-directory: ${{ matrix.model }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        model: [yolo11n, yolov8s-worldv2, yoloe11s]
+        model: [yolo11n, yolov8s-worldv2, yoloe11s, yolo26]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Test model
         working-directory: ${{ matrix.model }}
         run: cog predict -i image=@../assets/bus.jpg -i conf=0.25 -i iou=0.45
+      - name: Test model size selection (temporary, yolo26 only)
+        if: matrix.model == 'yolo26'
+        working-directory: ${{ matrix.model }}
+        run: cog predict -i image=@../assets/bus.jpg -i model_size=x
       - name: Push to Replicate
         if: github.ref == 'refs/heads/main'
         working-directory: ${{ matrix.model }}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ ultralytics/replicate/
 │   ├── cog.yaml              # Cog configuration
 │   ├── predict.py            # Prediction interface
 │   └── README.md             # Model documentation
+├── yolo26/                   # YOLO26 model deployment (selectable size n/s/m/l/x)
+│   ├── cog.yaml              # Cog configuration
+│   ├── predict.py            # Prediction interface
+│   └── README.md             # Model documentation
 ├── assets/                   # Sample images for workflow smoke tests
 │
 ├── .github/workflows/        # Automated deployment
@@ -106,6 +110,7 @@ pip install -r requirements.txt
 | `yolo11n/`         | `r8.im/ultralytics/yolo11n`         | `YOLO`      | Official YOLO11n object detection model                |
 | `yolov8s-worldv2/` | `r8.im/ultralytics/yolov8s-worldv2` | `YOLOWorld` | Open-vocabulary YOLOv8s WorldV2 model                  |
 | `yoloe11s/`        | `r8.im/ultralytics/yoloe-11s`       | `YOLOE`     | YOLOE-11S segmentation model with class prompt support |
+| `yolo26/`          | `r8.im/ultralytics/yolo26`          | `YOLO`      | YOLO26 detection with runtime size selection (n/s/m/l/x) |
 
 ## 🔧 Model Setup
 

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ pip install -r requirements.txt
 
 ## 🎯 Available Models
 
-| Directory          | Replicate model                     | Predictor   | Notes                                                  |
-| ------------------ | ----------------------------------- | ----------- | ------------------------------------------------------ |
-| `yolo11n/`         | `r8.im/ultralytics/yolo11n`         | `YOLO`      | Official YOLO11n object detection model                |
-| `yolov8s-worldv2/` | `r8.im/ultralytics/yolov8s-worldv2` | `YOLOWorld` | Open-vocabulary YOLOv8s WorldV2 model                  |
-| `yoloe11s/`        | `r8.im/ultralytics/yoloe-11s`       | `YOLOE`     | YOLOE-11S segmentation model with class prompt support |
+| Directory          | Replicate model                     | Predictor   | Notes                                                    |
+| ------------------ | ----------------------------------- | ----------- | -------------------------------------------------------- |
+| `yolo11n/`         | `r8.im/ultralytics/yolo11n`         | `YOLO`      | Official YOLO11n object detection model                  |
+| `yolov8s-worldv2/` | `r8.im/ultralytics/yolov8s-worldv2` | `YOLOWorld` | Open-vocabulary YOLOv8s WorldV2 model                    |
+| `yoloe11s/`        | `r8.im/ultralytics/yoloe-11s`       | `YOLOE`     | YOLOE-11S segmentation model with class prompt support   |
 | `yolo26/`          | `r8.im/ultralytics/yolo26`          | `YOLO`      | YOLO26 detection with runtime size selection (n/s/m/l/x) |
 
 ## 🔧 Model Setup

--- a/yolo26/README.md
+++ b/yolo26/README.md
@@ -1,0 +1,31 @@
+# YOLO26 Demo Deployment
+
+Deploy the official YOLO26 model to Replicate with PyTorch inference at <https://replicate.com/ultralytics/yolo26>.
+
+## Setup
+
+1. **Deploy to Replicate:**
+
+   ```bash
+   cog push r8.im/ultralytics/yolo26
+   ```
+
+## Model Details
+
+- **Model**: YOLO26 (selectable size: n/s/m/l/x)
+- **Format**: PyTorch (.pt)
+- **Use Case**: Demonstration of official Ultralytics model deployment with runtime size selection
+
+## Model Files
+
+**Note:** `download.py` stages all five YOLO26 weights (`yolo26n.pt`, `yolo26s.pt`, `yolo26m.pt`, `yolo26l.pt`, `yolo26x.pt`)
+before the container builds. The predictor loads `yolo26n.pt` on startup and only reloads when a request selects a
+different size, so repeated requests at the same size incur no reload cost.
+
+## Configuration
+
+- **GPU**: Disabled by default (CPU inference)
+- **Python**: 3.12 with PyTorch 2.0+
+- **Framework**: Ultralytics 8.4.75+
+- **Input**: Single image with selectable model size and configurable confidence/IoU thresholds and image size
+- **Output**: Annotated image with detected objects

--- a/yolo26/cog.yaml
+++ b/yolo26/cog.yaml
@@ -1,0 +1,13 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+build:
+  gpu: false
+  python_version: "3.12"
+  system_packages:
+    - "libglib2.0-0"
+    - "ffmpeg"
+  python_packages:
+    - "ultralytics>=8.4.75"
+
+predict: predict.py:Predictor
+image: r8.im/ultralytics/yolo26

--- a/yolo26/download.py
+++ b/yolo26/download.py
@@ -1,0 +1,21 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+from pathlib import Path
+
+from ultralytics import YOLO
+
+
+def main():
+    """Download all YOLO26 (n/s/m/l/x) weights and move to model directory."""
+    current_dir = Path(__file__).parent
+    for size in ("n", "s", "m", "l", "x"):
+        YOLO(current_dir / f"yolo26{size}.pt")
+
+    # List files in model directory
+    print(f"Files in {current_dir.name} directory:")
+    for file in sorted(current_dir.iterdir()):
+        print(f"  {file.stat().st_size:>10} {file.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/yolo26/predict.py
+++ b/yolo26/predict.py
@@ -1,0 +1,52 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+from __future__ import annotations
+
+from cog import BaseModel, BasePredictor, Input, Path
+from ultralytics import YOLO
+
+
+class Output(BaseModel):
+    """Output model for predictions."""
+
+    image: Path | None = None
+    json_str: str | None = None
+
+
+class Predictor(BasePredictor):
+    """YOLO26 model predictor for Replicate deployment with selectable model size (n/s/m/l/x)."""
+
+    def setup(self) -> None:
+        """Load the default YOLO26 model into memory."""
+        self.model_size = "n"
+        self.model = YOLO(f"yolo26{self.model_size}.pt")
+
+    def re_init_model(self, model_size: str) -> None:
+        """Reload the model only if the requested size differs from the currently loaded one."""
+        if model_size != self.model_size:
+            self.model = YOLO(f"yolo26{model_size}.pt")
+            self.model_size = model_size
+
+    def predict(
+        self,
+        image: Path = Input(description="Input image"),
+        model_size: str = Input(
+            description="Model size (n=nano, s=small, m=medium, l=large, x=extra-large)",
+            default="n",
+            choices=["n", "s", "m", "l", "x"],
+        ),
+        conf: float = Input(description="Confidence threshold", default=0.25, ge=0.0, le=1.0),
+        iou: float = Input(description="IoU threshold for NMS", default=0.45, ge=0.0, le=1.0),
+        imgsz: int = Input(description="Image size", default=640, choices=[320, 416, 512, 640, 832, 1024, 1280]),
+        return_json: bool = Input(description="Return detection results as JSON", default=False),
+    ) -> Output:
+        """Run inference and return annotated image with optional JSON results."""
+        self.re_init_model(model_size)
+        result = self.model(str(image), conf=conf, iou=iou, imgsz=imgsz)[0]
+        image_path = "output.png"
+        result.save(image_path)
+
+        if return_json:
+            return Output(image=Path(image_path), json_str=result.to_json())
+        else:
+            return Output(image=Path(image_path))


### PR DESCRIPTION
## Summary

Adds a `yolo26/` Cog deployment for YOLO26, exposing all five model sizes (`n/s/m/l/x`) within a **single** Replicate model (`r8.im/ultralytics/yolo26`) via a `model_size` dropdown — no need for five separate Replicate models.

## Details

- **`yolo26/predict.py`** — adds a `model_size` input (`choices=["n","s","m","l","x"]`, default `n`). `setup()` loads `yolo26n.pt`; `re_init_model()` reloads **only when the requested size differs** from the currently loaded one (tracked via `self.model_size`), so repeated same-size requests on a warm container do no reloading.
- **`yolo26/download.py`** — stages all five weights into the image at build time so no size triggers a network fetch at predict time.
- **`yolo26/cog.yaml`** — targets `r8.im/ultralytics/yolo26`, pinned to `ultralytics>=8.4.75` (required for YOLO26).
- **`yolo26/README.md`** — model card.
- **`.github/workflows/push.yml`** — adds `yolo26` to the build/test/push matrix.
- **`README.md`** — adds YOLO26 to the model table and repo-structure tree.

## Deployment

On merge to `main`, the existing `push.yml` workflow builds, smoke-tests, and runs `cog push` for `yolo26` automatically (the `cog push` step is gated `if: github.ref == 'refs/heads/main'`).

## Notes

- The CI smoke test (`cog predict`) exercises the default size (`n`) only; `s/m/l/x` load on real requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR adds a new `yolo26/` Replicate deployment, enabling YOLO26 inference with selectable model sizes and automated workflow coverage.

### 📊 Key Changes
- Added a new `yolo26/` deployment package with:
  - `predict.py` for Replicate inference
  - `cog.yaml` for build/runtime configuration
  - `README.md` for deployment and usage documentation
  - `download.py` to pre-download all YOLO26 weights (`n/s/m/l/x`)
- Introduced **runtime model size selection** for YOLO26, allowing users to choose between `n`, `s`, `m`, `l`, and `x` in a single deployment.
- Implemented **smart model reloading**:
  - Loads `yolo26n.pt` by default
  - Only reloads weights when a different size is requested
- Added configurable inference inputs:
  - confidence threshold
  - IoU threshold
  - image size
  - optional JSON output alongside the annotated image
- Updated the GitHub Actions push workflow to include `yolo26` in deployment smoke tests ✅
- Updated the root `README.md` to list YOLO26 as an available Replicate model and document its capabilities.

### 🎯 Purpose & Impact
- Makes **YOLO26**, the latest recommended Ultralytics model, available on Replicate 🎉
- Simplifies deployment by offering **multiple model sizes in one endpoint**, instead of requiring separate deployments for each variant.
- Improves efficiency by avoiding unnecessary model reloads, which can help reduce latency for repeated requests ⚡
- Expands user flexibility with both **visual output** and **JSON detections**, supporting demos, apps, and downstream integrations.
- Strengthens reliability by adding YOLO26 to automated workflow validation, helping catch deployment issues earlier 🔒