### PR TITLE
Fix ForwardRef crash on every prediction; make CI catch it

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,7 +41,14 @@ jobs:
         run: cog build
       - name: Test model
         working-directory: ${{ matrix.model }}
-        run: cog predict -i image=@../assets/bus.jpg -i conf=0.25 -i iou=0.45 -i return_json=true
+        # `cog predict` exits 0 even when the prediction raises, so capture output and fail on a traceback.
+        run: |
+          set -o pipefail
+          cog predict -i image=@../assets/bus.jpg -i conf=0.25 -i iou=0.45 -i return_json=true 2>&1 | tee predict.log
+          if grep -q "Traceback (most recent call last)" predict.log; then
+            echo "::error::cog predict raised an exception (see log above)"
+            exit 1
+          fi
       - name: Push to Replicate
         if: github.ref == 'refs/heads/main'
         working-directory: ${{ matrix.model }}

--- a/yolo11n/predict.py
+++ b/yolo11n/predict.py
@@ -13,6 +13,10 @@ class Output(BaseModel):
     json_str: str | None = None
 
 
+# Resolve PEP 563 string annotations so Cog's pydantic can build the Output schema (Path passed in explicitly).
+Output.update_forward_refs(Path=Path)
+
+
 class Predictor(BasePredictor):
     """YOLO11n model predictor for Replicate deployment."""
 

--- a/yolo26/predict.py
+++ b/yolo26/predict.py
@@ -13,6 +13,10 @@ class Output(BaseModel):
     json_str: str | None = None
 
 
+# Resolve PEP 563 string annotations so Cog's pydantic can build the Output schema (Path passed in explicitly).
+Output.update_forward_refs(Path=Path)
+
+
 class Predictor(BasePredictor):
     """YOLO26 model predictor for Replicate deployment with selectable model size (n/s/m/l/x)."""
 

--- a/yoloe11s/predict.py
+++ b/yoloe11s/predict.py
@@ -13,6 +13,10 @@ class Output(BaseModel):
     json_str: str | None = None
 
 
+# Resolve PEP 563 string annotations so Cog's pydantic can build the Output schema (Path passed in explicitly).
+Output.update_forward_refs(Path=Path)
+
+
 class Predictor(BasePredictor):
     """YOLOE: Real-Time Seeing Anything model predictor for Replicate deployment."""
 

--- a/yolov8s-worldv2/predict.py
+++ b/yolov8s-worldv2/predict.py
@@ -13,6 +13,10 @@ class Output(BaseModel):
     json_str: str | None = None
 
 
+# Resolve PEP 563 string annotations so Cog's pydantic can build the Output schema (Path passed in explicitly).
+Output.update_forward_refs(Path=Path)
+
+
 class Predictor(BasePredictor):
     """YOLOv8s WorldV2 model predictor for Replicate deployment."""
 


### PR DESCRIPTION
## Problem

Every model (not just yolo26) crashed on **every** `predict()` call — including the default `return_json=false` path:

```
pydantic.errors.ConfigError: field "image" not yet prepared so type is still a
ForwardRef, you might need to call Output.update_forward_refs().
```

Two compounding bugs let this ship:

1. **The crash.** `from __future__ import annotations` (kept because the formatter requires it so `Path | None` works on Python 3.8) turns `predict()`'s return annotation into the string `"Output"`. Cog reads `inspect.signature(predict).return_annotation` and loads the predictor module in a namespace where `Path` isn't visible, so it never resolves the `Output` field annotations. Constructing `Output(...)` then raises.
2. **CI false-green.** `cog predict` exits 0 even when the prediction raises, so the smoke test reported success while every prediction was crashing. (The earlier `return_json=true` test "passed" for the same reason.)

## Fix

- **`predict.py` (all four):** add `Output.update_forward_refs(Path=Path)` after the `Output` class — explicitly resolving the postponed annotations and passing `Path` in, since Cog's loader namespace lacks it. Keeps the future import, so it survives the formatter.
- **`push.yml`:** the `Test model` step now captures `cog predict` output and **fails on a Python traceback**, so a crashing prediction can no longer pass CI.

## Verification

Reproduced and fixed locally against **all four real `predict.py` files** through Cog's actual loader (`cog 0.9.x` / `pydantic v1`, matching the deployed runtime):

- Unfixed (`origin/main`) → fails with the identical `ConfigError` on both `return_json` branches.
- Fixed → both branches build `Output` for all four models.

On merge, the hardened CI smoke test gates the deploy, then `cog push` redeploys all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves reliability in the `ultralytics/replicate` deployment workflow by fixing Pydantic schema issues in multiple model predictors and making CI tests correctly fail when `cog predict` throws hidden runtime errors.

### 📊 Key Changes
- Added `Output.update_forward_refs(Path=Path)` to the `predict.py` files for:
  - `yolo11n`
  - `yolo26`
  - `yoloe11s`
  - `yolov8s-worldv2`
- This resolves deferred type annotations so Cog’s Pydantic schema generation can correctly understand `Path` fields. 🧩
- Updated the GitHub Actions workflow in `.github/workflows/push.yml` to better validate predictions during CI. ✅
- The `cog predict` test step now:
  - captures command output to a log
  - checks for Python traceback text
  - explicitly fails the workflow if an exception occurred, even if `cog predict` exits with status `0` ⚠️
- Added clearer CI error reporting to make failures easier to spot and debug. 🔍

### 🎯 Purpose & Impact
- Prevents schema-generation bugs that could break Replicate model predictors at runtime. 🚀
- Improves compatibility and stability across several deployed Ultralytics models, including YOLO11 and YOLO26. 🤝
- Makes CI much more trustworthy by catching silent prediction failures that were previously slipping through. 🛡️
- Reduces the chance of broken models being pushed to Replicate from the `main` branch. 📦
- Helps developers diagnose issues faster with better logging and explicit workflow failures. ⏱️