### PR TITLE
Fix Replicate metadata sync 403 in CI and matrix fail-fast

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,7 @@ jobs:
     name: Build, Test & Push Model
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         model: [yolo11n, yolov8s-worldv2, yoloe11s, yolo26/detect, yolo26/seg, yolo26/sem, yolo26/cls, yolo26/pose, yolo26/obb]
     steps:

--- a/replicate_metadata.py
+++ b/replicate_metadata.py
@@ -32,6 +32,8 @@ import urllib.request
 from pathlib import Path
 
 API_BASE = "https://api.replicate.com/v1"
+# The default urllib User-Agent is blocked (HTTP 403) by Replicate's CDN from datacenter IPs (e.g. CI runners).
+USER_AGENT = "ultralytics-replicate-metadata/1.0 (+https://github.com/ultralytics/replicate)"
 
 # Fields shared by every model in this repo.
 GITHUB_URL = "https://github.com/ultralytics/ultralytics"
@@ -141,6 +143,7 @@ def api(method: str, path: str, token: str, body: dict | None = None) -> tuple[i
     req = urllib.request.Request(f"{API_BASE}{path}", data=data, method=method)
     req.add_header("Authorization", f"Bearer {token}")
     req.add_header("Content-Type", "application/json")
+    req.add_header("User-Agent", USER_AGENT)
     try:
         with urllib.request.urlopen(req) as resp:
             return resp.status, _parse(resp.read())
@@ -178,6 +181,19 @@ def build_payloads(owner: str, name: str, model_dir: Path) -> tuple[dict, dict]:
     return create, update
 
 
+def ensure_created(slug: str, create_payload: dict, token: str) -> bool:
+    """Create the model; treat an 'already exists' conflict as success. Return False only on a real create error."""
+    status, body = api("POST", "/models", token, create_payload)
+    if status in (200, 201):
+        print(f"✓ {slug}: created (visibility={VISIBILITY}, hardware={HARDWARE})")
+        return True
+    if status == 409 or "already exists" in json.dumps(body).lower():
+        print(f"• {slug}: exists")
+        return True
+    print(f"✗ {slug}: create failed ({status}): {body}", file=sys.stderr)
+    return False
+
+
 def sync(owner: str, name: str, model_dir: Path, token: str, dry_run: bool) -> bool:
     """Create the model if missing, then patch its metadata. Return False on a fatal (create/get) error."""
     slug = f"{owner}/{name}"
@@ -189,17 +205,16 @@ def sync(owner: str, name: str, model_dir: Path, token: str, dry_run: bool) -> b
         return True
 
     status, _ = api("GET", f"/models/{slug}", token)
-    if status == 404:
-        c_status, c_body = api("POST", "/models", token, create_payload)
-        if c_status not in (200, 201):
-            print(f"✗ {slug}: create failed ({c_status}): {c_body}", file=sys.stderr)
-            return False
-        print(f"✓ {slug}: created (visibility={VISIBILITY}, hardware={HARDWARE})")
-    elif status == 200:
+    if status == 200:
         print(f"• {slug}: exists")
+    elif status == 404:
+        if not ensure_created(slug, create_payload, token):
+            return False
     else:
-        print(f"✗ {slug}: unexpected GET status {status}", file=sys.stderr)
-        return False
+        # GET can be unreliable for some tokens/CDN paths (e.g. 403); fall back to create-or-conflict.
+        print(f"… {slug}: GET returned {status}; attempting create-or-update", file=sys.stderr)
+        if not ensure_created(slug, create_payload, token):
+            return False
 
     u_status, u_body = api("PATCH", f"/models/{slug}", token, update_payload)
     if u_status == 200:


### PR DESCRIPTION
Hotfix for the deploy run that failed on yolo11n with `GET status 403` (Replicate CDN blocks the default urllib User-Agent from CI IPs), which then cancelled the other 8 jobs via fail-fast.

- Explicit `User-Agent` on all Replicate API requests
- Resilient GET → create-or-conflict (`ensure_created`) instead of hard-fail on 403
- `fail-fast: false` on the deploy matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves Replicate model publishing reliability by making CI more resilient and hardening model metadata sync against API/CDN access issues 🚀

### 📊 Key Changes
- Added `fail-fast: false` to the GitHub Actions matrix in `.github/workflows/push.yml` ✅
  - This allows all model build/test/push jobs to continue running even if one model fails.
- Added a custom `User-Agent` header in `replicate_metadata.py` 🌐
  - This avoids HTTP 403 errors caused by Replicate’s CDN blocking the default Python `urllib` user agent from CI environments.
- Introduced a new `ensure_created()` helper function 🛠️
  - Centralizes model creation logic.
  - Treats “already exists” responses as success instead of failure.
- Made model sync more fault-tolerant during API checks 🔁
  - If a model `GET` request returns `404`, it creates the model as before.
  - If `GET` returns unexpected statuses like `403`, it now falls back to a create-or-update flow instead of stopping immediately.

### 🎯 Purpose & Impact
- Makes automated publishing to Replicate more reliable in CI pipelines 🤖
- Prevents one failing model job from cancelling the rest of the workflow, improving visibility across all model variants 📦
- Reduces failures caused by network/CDN quirks or token-specific API behavior 🔒
- Improves idempotency: rerunning the sync is safer because existing models are handled gracefully ♻️
- Helps maintainers ship and update Ultralytics models on Replicate with fewer manual retries and less fragile automation ⚡