### PR TITLE
Add ultralytics/retry to deploy network steps to reduce flakiness

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,6 +16,9 @@ jobs:
   build_test_push:
     name: Build, Test & Push Model
     runs-on: ubuntu-latest
+    env:
+      # Job-level so the composite retry action (Sync metadata) reliably inherits it.
+      REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -30,16 +33,21 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
       - name: Install dependencies
-        run: uv pip install --system ultralytics --extra-index-url https://download.pytorch.org/whl/cpu
+        uses: ultralytics/actions/retry@main
+        with:
+          run: uv pip install --system ultralytics --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Setup Cog
         uses: replicate/setup-cog@v2
         with:
           token: ${{ secrets.REPLICATE_API_TOKEN }}
       - name: Download model weights
-        run: python ${{ matrix.model }}/download.py
+        uses: ultralytics/actions/retry@main
+        with:
+          run: python ${{ matrix.model }}/download.py
       - name: Build model image
-        working-directory: ${{ matrix.model }}
-        run: cog build
+        uses: ultralytics/actions/retry@main
+        with:
+          run: cd ${{ matrix.model }} && cog build
       - name: Test model
         working-directory: ${{ matrix.model }}
         # `cog predict` exits 0 even when the prediction raises, so capture output and fail on a traceback.
@@ -53,10 +61,11 @@ jobs:
       - name: Sync Replicate model metadata
         # Creates the model if missing (so `cog push` succeeds) and syncs description/readme/links/cover.
         if: github.ref == 'refs/heads/main'
-        env:
-          REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
-        run: python replicate_metadata.py --dir "${{ matrix.model }}"
+        uses: ultralytics/actions/retry@main
+        with:
+          run: python replicate_metadata.py --dir "${{ matrix.model }}"
       - name: Push to Replicate
         if: github.ref == 'refs/heads/main'
-        working-directory: ${{ matrix.model }}
-        run: cog push
+        uses: ultralytics/actions/retry@main
+        with:
+          run: cd ${{ matrix.model }} && cog push


### PR DESCRIPTION
Wraps the transient network-bound steps in `push.yml` with `ultralytics/actions/retry@main`: install deps, download weights, `cog build`, metadata sync, and `cog push`.

- Moves `REPLICATE_API_TOKEN` to job-level env so the composite retry action inherits it.
- Uses `cd <dir> && ...` for build/push (`uses:` steps can't take `working-directory`).
- Leaves **Test model** unwrapped so a real traceback fails fast (no wasted retries).

Caveat: step-level retry can't recover a **lost runner** (what hit `yolo26-sem`) — that's a job-level rerun concern, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR makes the Replicate model publish workflow more reliable by adding automatic retries to key CI steps and ensuring the Replicate API token is available throughout the job.

### 📊 Key Changes
- 🛠️ Added a job-level `REPLICATE_API_TOKEN` environment variable in `.github/workflows/push.yml` so all relevant steps, including composite retry actions, can access it consistently.
- 🔁 Wrapped several failure-prone workflow steps with `ultralytics/actions/retry@main`, including:
  - dependency installation
  - model weight download
  - Docker/Cog image build
  - Replicate metadata sync
  - model push to Replicate
- 📦 Updated `Build model image` and `Push to Replicate` steps to run through retry-wrapped shell commands using `cd ${{ matrix.model }} && ...` instead of `working-directory`.
- 🧾 Reworked the metadata sync step so it also benefits from retry behavior while still running only on the `main` branch.

### 🎯 Purpose & Impact
- ✅ Reduces CI/CD failures caused by temporary network issues, package install hiccups, or flaky external services.
- 🚀 Improves the reliability of publishing Ultralytics models to Replicate, especially for automated pushes from `main`.
- 🔐 Ensures authentication is passed more dependably to all steps that need Replicate access.
- ⏱️ Helps maintainers spend less time rerunning failed workflows and more time shipping updates smoothly.