### PR TITLE
Enforce logo cover_image_url on every metadata sync

### DIFF
--- a/replicate_metadata.py
+++ b/replicate_metadata.py
@@ -11,7 +11,8 @@ For each model directory (discovered from its ``cog.yaml`` ``image:`` target) th
 
 The Replicate API splits writable fields between the two endpoints (see https://replicate.com/docs/reference/http):
 
-- create-only: ``visibility``, ``hardware``, ``cover_image_url``
+- create-only: ``visibility``, ``hardware`` (docs also list ``cover_image_url`` here, but we additionally re-attempt it
+  on update via a separate best-effort PATCH so the logo stays enforced on existing models too)
 - update-only: ``readme``, ``weights_url``
 - either:      ``description``, ``github_url``, ``paper_url``, ``license_url``
 
@@ -46,8 +47,8 @@ YOLO26_PLATFORM_URL = "https://platform.ultralytics.com/ultralytics/yolo26"
 
 # Default cover image for newly created model pages. ``cover_image_url`` takes a URL (Replicate fetches it), not a file
 # upload, so we point at the Ultralytics logo hosted in the public ultralytics/assets repo (stable raw URL, verified
-# HTTP 200 image/png). This is create-only: it brands the 5 new YOLO26 task models at creation; already-existing models
-# keep their current cover (change those in the Replicate web UI). Per-model SPECS may override.
+# HTTP 200 image/png). Set on create AND re-attempted on every update (see sync), so all models — including existing
+# ones and any whose cover drifted to a prediction output — converge on this logo. Per-model SPECS may override.
 COVER_IMAGE_URL = (
     "https://raw.githubusercontent.com/ultralytics/assets/main/yolo/ultralytics_yolo_logomark_blue_512_512.png"
 )
@@ -201,7 +202,9 @@ def sync(owner: str, name: str, model_dir: Path, token: str, dry_run: bool) -> b
 
     if dry_run:
         upd = {k: (f"<{len(v)} chars>" if k == "readme" else v) for k, v in update_payload.items()}
+        cover = create_payload.get("cover_image_url")
         print(f"[dry-run] {slug}\n  create: {json.dumps(create_payload)}\n  update: {json.dumps(upd)}")
+        print(f"  cover-patch: {json.dumps({'cover_image_url': cover})}")
         return True
 
     status, _ = api("GET", f"/models/{slug}", token)
@@ -221,6 +224,17 @@ def sync(owner: str, name: str, model_dir: Path, token: str, dry_run: bool) -> b
         print(f"✓ {slug}: metadata synced (description, readme, urls)")
     else:  # non-fatal: the model exists/pushes fine even if the page text lagged
         print(f"⚠ {slug}: metadata PATCH failed ({u_status}): {u_body}", file=sys.stderr)
+
+    # cover_image_url is documented as create-only; attempt it on update too as a SEPARATE best-effort request so a
+    # rejection can't block the metadata sync above. Re-asserts the logo on every model each run (resetting a cover that
+    # drifted to a prediction output, and migrating already-existing models to the current logo).
+    cover = create_payload.get("cover_image_url")
+    if cover:
+        c_status, _ = api("PATCH", f"/models/{slug}", token, {"cover_image_url": cover})
+        if c_status == 200:
+            print(f"✓ {slug}: cover_image_url update accepted")
+        else:
+            print(f"⚠ {slug}: cover_image_url update not accepted ({c_status}); set cover in web UI", file=sys.stderr)
     return True
 
 


### PR DESCRIPTION
Re-asserts the shared 512px Ultralytics logo (`ultralytics/assets`) as the cover on **all 9** models on every deploy.

Why: `cover_image_url` is documented create-only, so existing covers — and new models whose cover drifted to a prediction output (`yolo26-obb`, `yolo26-cls`) — couldn't be reset via the documented update. This adds a **separate best-effort cover PATCH** after the metadata PATCH (kept separate so a rejection of the create-only field can't block the description/readme/url sync).

If Replicate honors `cover_image_url` on PATCH, all covers converge on the 512 logo; if not, it's a no-op warning (and we'd fall back to the web UI). I'll verify the live covers after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🖼️ This PR updates Replicate metadata syncing so the Ultralytics cover image is now re-applied on existing models during updates, not just when models are first created.

### 📊 Key Changes
- Added a **best-effort `cover_image_url` PATCH step** during metadata sync for existing Replicate models.
- Updated comments and documentation in `replicate_metadata.py` to reflect that `cover_image_url` is now:
  - still set on model creation
  - also re-attempted on updates to keep branding consistent
- Improved **dry-run output** to show the planned cover image patch alongside create and update payloads.
- Kept the cover image update as a **separate non-blocking request**, so failure to update the image does not interrupt normal metadata syncing.
- Clarified that this helps restore the intended Ultralytics logo if a model cover has **drifted** to something else, such as a prediction output.

### 🎯 Purpose & Impact
- Ensures **more consistent branding** across Replicate model pages by reasserting the Ultralytics logo automatically 🎨
- Helps **existing models** adopt the correct cover image, not just newly created ones.
- Reduces manual cleanup in the Replicate web UI by automatically correcting covers when possible ⚙️
- Minimizes risk because the cover image update is **best-effort only** and won’t block other metadata updates if Replicate rejects it.
- Makes sync behavior more transparent for maintainers through clearer logs and dry-run previews 🔍