### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: ultralytics/actions/setup-uv@main
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: 3.12
       - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: ultralytics/actions/setup-uv@main
       - name: Install dependencies
         uses: ultralytics/actions/retry@main
         with:


### PR DESCRIPTION
## Summary
- replace all 2 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 2 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated GitHub Actions workflows to use Ultralytics’ shared `setup-uv` action. ⚙️

### 📊 Key Changes

- Replaced `astral-sh/setup-uv@v6` with `ultralytics/actions/setup-uv@main` in:
  - Continuous integration (`ci.yml`)
  - Push workflow (`push.yml`)
- Kept the existing Python setup and dependency installation steps unchanged.

### 🎯 Purpose & Impact

- 🧩 Standardizes `uv` environment setup across Ultralytics repositories.
- 🔄 Centralizes workflow maintenance in the shared Ultralytics actions repository.
- ✅ Helps keep CI and push workflows consistent and easier to update.
- 🚀 No direct changes to application behavior; the impact is limited to development and automation workflows.