### PR TITLE
Standardize .github configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# Dependabot for package version updates
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/.github/workflows"
+    schedule:
+      interval: weekly
+      time: "04:00"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v7
         with:
-          python-version: 3.12
+          python-version: "3.12"
       - name: Setup uv
         uses: ultralytics/actions/setup-uv@main
       - name: Install dependencies


### PR DESCRIPTION
Aligns .github with the current Ultralytics repository standard.

- Add dependabot.yml for weekly GitHub Actions version updates
- Quote python-version in push.yml so it is read as a string

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Standardized GitHub configuration by adding weekly Dependabot checks for GitHub Actions and ensuring the workflow’s Python version is treated as a string.

### 📊 Key Changes

- Added `.github/dependabot.yml` to check for GitHub Actions updates weekly at 04:00.
- Limited Dependabot to five open pull requests and applied the `dependencies` label.
- Quoted `python-version: "3.12"` in `.github/workflows/push.yml`.

### 🎯 Purpose & Impact

- GitHub Actions dependency updates can now be raised automatically through Dependabot.
- The push workflow explicitly passes Python 3.12 as a string to `actions/setup-python`.
- No runtime application behavior changed.