### PR TITLE
Accept normalized CLA signature comments

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   CLA:
-    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA'))
+    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || contains(github.event.comment.body, 'I have read the CLA Document and I sign the CLA')))
     concurrency:
       group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Valid CLA signature comments with trailing whitespace or surrounding Markdown currently never reach the normalized action matcher because the workflow gate requires exact equality.

This makes only the signature gate permissive. The `recheck` command remains exact, and the action still decides whether a single normalized line is a valid signature, so quoted or instructional text does not sign the CLA.

Related matcher fix: ultralytics/actions#894

Validation:
- `actionlint .github/workflows/cla.yml`
- `npx prettier@3.8.5 --check .github/workflows/cla.yml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the CLA workflow gate to recognize comments containing the normalized CLA signature text, allowing trailing whitespace or surrounding Markdown to reach the action matcher.

### 📊 Key Changes
- Replaced the exact CLA signature comparison in `.github/workflows/cla.yml` with a `contains(...)` check.
- Kept the `recheck` command comparison exact.
- Preserved validation by the action’s normalized single-line matcher, so surrounding quoted or instructional text does not independently sign the CLA.

### 🎯 Purpose & Impact
- CLA signature comments with formatting or trailing whitespace can now be processed by the action instead of being blocked by the workflow condition.
- The change is limited to the signature gate; `recheck` behavior remains unchanged.